### PR TITLE
Allow hosting wormhole behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,27 @@ validate_certs=false
 [galaxy_server.official]
 url=https://galaxy.ansible.com/
 ```
+
+## behind a proxy
+
+If you are using a proxy with a subpath, have a look at the dev.yml file.
+An matching example nginx config might look like this:
+
+```sh
+    [...]
+    upstream wormhole {
+        server wormhole:80;
+    }
+
+    server {
+        [...]
+        ## wormhole
+        location /wormhole/ {
+            proxy_pass http://wormhole/;
+        }
+        location /ansible {
+            default_type        application/json;
+        }
+```
+
+Keep an eye on the trailing backslash in the location and proxy_pass line. Without them it will probably not work.

--- a/compose/Dockerfile.nginx
+++ b/compose/Dockerfile.nginx
@@ -1,7 +1,7 @@
 FROM nginx
 
-# Default config expects bind mount / volume @ /data/wormhole/web
-RUN mkdir -p /data/wormhole/web/download/
+# Default config expects bind mount / volume @ /data/ansible/
+RUN mkdir -p /data/ansible/
 RUN mkdir /config
 COPY nginx.conf /config
 

--- a/compose/nginx.conf
+++ b/compose/nginx.conf
@@ -51,12 +51,6 @@ http {
         location /download {
             default_type application/gzip;
         }
-        location /api {
-            proxy_pass http://wormhole/api;
-        }
-        location /docs {
-            proxy_pass http://wormhole/docs;
-        }
         location / {
             proxy_pass http://wormhole/;
         }

--- a/dev.yml
+++ b/dev.yml
@@ -10,13 +10,22 @@ services:
       - "./compose/data:/mirror"
     networks:
       - wormhole_net
+    command:
+      - "uvicorn"
+      - "app.main:app"
+      - "--host"
+      - "0.0.0.0"
+      - "--port"
+      - "80"
+      #- "--root-path"  # use these two lines if you are running behind a proxy
+      #- "/wormhole"     # that uses a subpath, needs to be different from the download subpath
   webserver:
     image: webserver
     build:
       context: ./compose
       dockerfile: Dockerfile.nginx
     volumes:
-      - "./compose/data:/data/ansible/web/download:ro"
+      - "./compose/data:/data/ansible:ro"
     ports:
       - "80:80"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       context: ./compose
       dockerfile: Dockerfile.nginx
     volumes:
-      - "data:/data/ansible/web/download:ro"
+      - "data:/data/ansible:ro"
     ports:
       - "80:80"
     networks:


### PR DESCRIPTION
Uvicorn needs a special parameter to be able to be hosted behind a subpath.
Additionally, reworked directory structure in docker-compose.

closes #6

Signed-off-by: Tim Beermann <beermann@osism.tech>
