### PR TITLE
Allow client to read yaml file.

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -16,6 +16,22 @@ Mirror two collections and one role:
 python3 main.py --wormhole-endpoint http://1.2.3.4 mirror -c osism.services -c osism.validations -r geerlingguy.ansible
 ```
 
+Use a yaml file (e.g. _mirror.yml_):
+
+```yaml
+roles:
+  - geerlingguy.ansible
+collections:
+  - osism.services
+  - osism.validations
+```
+
+```sh
+python3 main.py --wormhole-endpoint http://1.2.3.4 mirror -f mirror.yml
+```
+
+A combination of "-c", "-r" and "-f" is also possible.
+
 You might also set the wormhole endpoint via an environment variable:
 
 ```sh

--- a/client/main.py
+++ b/client/main.py
@@ -1,6 +1,7 @@
+import os
 import requests
 import typer
-import os
+import yaml
 
 from typing import List, Optional
 
@@ -17,6 +18,9 @@ def mirror(
         ),
         collections: Optional[List[str]] = typer.Option(
             [], "--collection", "-c", help="OPTIONAL,MULTI-USE - e.g. osism.validations"
+        ),
+        config_file: Optional[str] = typer.Option(
+            "", "--file", "-f", help="OPTIONAL,SINGLE-USE - e.g. mirror.yml"
         )
 ):
     """
@@ -25,6 +29,11 @@ def mirror(
     Example call: python3 main.py mirror osism.sonic osism.validations
     """
     url = f"{settings['api_url']}/ansible/api/mirror"
+    if config_file != "":
+        with open(config_file, "r") as file:
+            data = yaml.safe_load(file)
+        roles = roles + data["roles"]
+        collections = collections + data["collections"]
     payload = {
         "roles": roles,
         "collections": collections

--- a/client/mirror.yml.example
+++ b/client/mirror.yml.example
@@ -1,0 +1,5 @@
+roles:
+  - geerlingguy.ansible
+collections:
+  - osism.validations
+  - osism.sonic

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.25.1
 typer>=0.7.0
+PyYAML>=6.0


### PR DESCRIPTION
closes #4

Required since it is not very practical to construct a client call for hundrets of roles and collections, especially when this should be executed periodically.

Signed-off-by: Tim Beermann <beermann@osism.tech>
