### PR TITLE
Remove bug that had an additional "ansible/" subpath inside the expected API URL. This originated from testing environments where wormhole was indeed hosted on something like 1.2.3.4/ansible/api.

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -28,7 +28,7 @@ def mirror(
 
     Example call: python3 main.py mirror osism.sonic osism.validations
     """
-    url = f"{settings['api_url']}/ansible/api/mirror"
+    url = f"{settings['api_url']}/api/mirror"
     if config_file != "":
         with open(config_file, "r") as file:
             data = yaml.safe_load(file)


### PR DESCRIPTION
Signed-off-by: Tim Beermann <beermann@osism.tech>
