### PR TITLE
Enable container image building

### DIFF
--- a/.github/workflows/build-wormhole-client.yml
+++ b/.github/workflows/build-wormhole-client.yml
@@ -1,0 +1,46 @@
+---
+name: Build wormhole client container image
+
+"on":
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build container image
+        run: scripts/build.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: wormhole-client
+          REPOSITORY: osism/wormhole-client
+          CONTEXT: client
+
+      - name: Push container image
+        run: scripts/push.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: wormhole-client
+          REPOSITORY: osism/wormhole-client
+        if: |
+          github.ref == 'refs/heads/main'

--- a/.github/workflows/build-wormhole.yml
+++ b/.github/workflows/build-wormhole.yml
@@ -1,0 +1,47 @@
+---
+name: Build wormhole container image
+
+"on":
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build container image
+        run: scripts/build.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: wormhole
+          REPOSITORY: osism/wormhole
+          BUILD_OPTS: --file compose/Dockerfile.app
+          CONTEXT: .
+
+      - name: Push container image
+        run: scripts/push.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: wormhole
+          REPOSITORY: osism/wormhole
+        if: |
+          github.ref == 'refs/heads/main'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -x
+
+# Available environment variables
+#
+# BUILD_OPTS
+# DOCKER_REGISTRY
+# IMAGE
+# REPOSITORY
+# VERSION
+
+# Set default values
+
+BUILD_OPTS=${BUILD_OPTS:-}
+CREATED=$(date --rfc-3339=ns)
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
+REVISION=$(git rev-parse HEAD)
+VERSION=${VERSION:-latest}
+
+if [[ -n $DOCKER_REGISTRY ]]; then
+    REPOSITORY="$DOCKER_REGISTRY/$REPOSITORY"
+fi
+
+pushd "${CONTEXT}" || exit
+docker buildx build \
+    --load \
+    --build-arg "VERSION=$VERSION" \
+    --tag "$REPOSITORY:$REVISION" \
+    --label "org.opencontainers.image.created=$CREATED" \
+    --label "org.opencontainers.image.revision=$REVISION" \
+    --label "org.opencontainers.image.version=$VERSION" \
+    $BUILD_OPTS .
+popd || exit

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -x
+
+# Available environment variables
+#
+# DOCKER_REGISTRY
+# REPOSITORY
+# VERSION
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
+REVISION=$(git rev-parse HEAD)
+VERSION=${VERSION:-latest}
+
+if [[ -n $DOCKER_REGISTRY ]]; then
+    REPOSITORY="$DOCKER_REGISTRY/$REPOSITORY"
+fi
+
+docker tag "$REPOSITORY:$REVISION" "$REPOSITORY:$VERSION"
+docker push "$REPOSITORY:$VERSION"
+docker rmi "$REPOSITORY:$VERSION"


### PR DESCRIPTION
Container images should be build automatically. This still needs to be extended with a version, etc. Currently this is required, to be able to battle test this on Kubernetes and to create the first Helm-Charts.

Signed-off-by: Tim Beermann <beermann@osism.tech>
