### PR TITLE
bump fastapi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.88.0
+fastapi>=0.92.0
 pydantic>=1.9.0
 requests>=2.25.1
 uvicorn>=0.20.0


### PR DESCRIPTION
changed fastapi version to 0.92.0 which fixes a security issue.

Signed-off-by: Tim Beermann <beermann@osism.tech>
